### PR TITLE
removed httpUri from CreateSchema, use grpc for querying schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 before_script:
 - dgraph zero &
 - ZERO_PID=$!
-- dgraph server --lru_mb 1024 &
+- dgraph alpha --lru_mb 1024 &
 - SERVER_PID=$!
 script:
 - go test -v -covermode=count -coverprofile=coverage.out

--- a/mutate_test.go
+++ b/mutate_test.go
@@ -13,6 +13,15 @@ type TestNode struct {
 	Field string `json:"field,omitempty"`
 }
 
+type TestCustomNode struct {
+	UID   string `json:"uid,omitempty"`
+	Field string `json:"field,omitempty"`
+}
+
+func (n TestCustomNode) NodeType() string {
+	return "custom_node_type"
+}
+
 func TestAddNode(t *testing.T) {
 	testData := TestNode{"", "test"}
 
@@ -24,9 +33,14 @@ func TestAddNode(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Error(err)
+	}
+
+	tx = c.NewTxn()
 
 	query := `
-	query {
+	{
 		data(func: has(test_node)) {
 			uid
 			field
@@ -36,6 +50,49 @@ func TestAddNode(t *testing.T) {
 
 	var result struct {
 		Data []TestNode
+	}
+
+	resp, err := tx.Query(context.Background(), query)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := json.Unmarshal(resp.Json, &result); err != nil {
+		t.Error(err)
+	}
+
+	assert.Len(t, result.Data, 1)
+	assert.Equal(t, uid, result.Data[0].UID)
+}
+
+func TestAddCustomeNode(t *testing.T) {
+	testData := TestCustomNode{"", "test"}
+
+	c := newDgraphClient()
+	defer dropAll(c)
+
+	tx := c.NewTxn()
+	uid, err := Mutate(context.Background(), tx, &testData)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Error(err)
+	}
+
+	tx = c.NewTxn()
+
+	query := `
+	query {
+		data(func: has(custom_node_type)) {
+			uid
+			field
+		}
+	}
+	`
+
+	var result struct {
+		Data []TestCustomNode
 	}
 
 	resp, err := tx.Query(context.Background(), query)

--- a/schema_test.go
+++ b/schema_test.go
@@ -48,19 +48,18 @@ func TestMarshalSchema(t *testing.T) {
 
 func TestCreateSchema(t *testing.T) {
 	c := newDgraphClient()
+	defer dropAll(c)
 	// make sure empty first, so no conflicts
-	conflict, err := CreateSchema(c, "localhost:8080", &User{})
+	conflict, err := CreateSchema(c, &User{})
 	if err != nil {
 		t.Error(err)
 	}
 	assert.Empty(t, conflict)
 
-	conflict, err = CreateSchema(c, "localhost:8080", &NewUser{})
+	conflict, err = CreateSchema(c, &NewUser{})
 	if err != nil {
 		t.Error(err)
 	}
 	// should return conflicts for username and email
 	assert.Len(t, conflict, 2)
-
-	dropAll(c)
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -12,6 +12,7 @@ type User struct {
 	Username string   `json:"username,omitempty" dgraph:"index=hash"`
 	Email    string   `json:"email,omitempty" dgraph:"index=hash upsert"`
 	Password string   `json:"password,omitempty"`
+	Mobiles  []string `json:"mobiles,omitempty"`
 	Schools  []School `json:"schools,omitempty" dgraph:"count reverse"`
 }
 
@@ -29,18 +30,20 @@ type NewUser struct {
 
 func TestMarshalSchema(t *testing.T) {
 	schema := marshalSchema(nil, User{})
-	assert.Len(t, schema, 7)
+	assert.Len(t, schema, 8)
 	assert.Contains(t, schema, "user")
 	assert.Contains(t, schema, "school")
 	assert.Contains(t, schema, "username")
 	assert.Contains(t, schema, "email")
 	assert.Contains(t, schema, "password")
 	assert.Contains(t, schema, "name")
+	assert.Contains(t, schema, "mobiles")
 	assert.Contains(t, schema, "schools")
 	assert.Equal(t, "username: string @index(hash) .", schema["username"].String())
 	assert.Equal(t, "email: string @index(hash) @upsert .", schema["email"].String())
 	assert.Equal(t, "password: string .", schema["password"].String())
 	assert.Equal(t, "name: string @index(term) .", schema["name"].String())
+	assert.Equal(t, "mobiles: [string] .", schema["mobiles"].String())
 	assert.Equal(t, "schools: uid @count @reverse .", schema["schools"].String())
 	assert.Equal(t, "school: string .", schema["school"].String())
 	assert.Equal(t, "user: string .", schema["user"].String())


### PR DESCRIPTION
No need to pass `httpUri` in `CreateSchema` anymore, because we can use dgo client using gRpc to query schema. https://github.com/dgraph-io/dgo/issues/23