### PR TITLE
Exclude parsing of reverse edges

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -157,7 +157,8 @@ func (t *TypeSchema) Marshal(parseType bool, models ...interface{}) {
 			parse := s.Predicate != "" &&
 				s.Predicate != "uid" && // don't parse uid
 				s.Predicate != dgraphTypePredicate && // don't parse dgraph.type
-				!strings.Contains(s.Predicate, "|") // don't parse facet
+				!strings.Contains(s.Predicate, "|") && // don't parse facet
+				s.Predicate[0] != '~' // don't parse reverse edge
 			if parse {
 				// one-to-one and many-to-many edge
 				if s.Type == "uid" || s.Type == "[uid]" {


### PR DESCRIPTION
While reviewing trying to fix #42, I figured out that my problems with reverse edges were a separate issue. This pull requests excludes reverse edges from marshalling, just like facets and UIDs.