### PR TITLE
avoid marshalling already visited nodes

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -128,6 +128,9 @@ func (t *TypeSchema) Marshal(parseType bool, models ...interface{}) {
 		}
 
 		nodeType := GetNodeType(model)
+		if _, ok := t.Types[nodeType]; ok {
+			return
+		}
 		if parseType {
 			t.Types[nodeType] = make(SchemaMap)
 		}


### PR DESCRIPTION
In my local testing, this change fixes the issues with circular struct references when generating the schema. I can't say that this is the only or best approach since I didn't review all of the callers of TypeSchema.Marshal.