### PR TITLE
Fix schema string for list predicates

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -59,7 +59,11 @@ type Schema struct {
 }
 
 func (s Schema) String() string {
-	schema := fmt.Sprintf("%s: %s ", s.Predicate, s.Type)
+	t := s.Type
+	if s.List {
+		t = fmt.Sprintf("[%s]", t)
+	}
+	schema := fmt.Sprintf("%s: %s ", s.Predicate, t)
 	if s.Index {
 		schema += fmt.Sprintf("@index(%s) ", strings.Join(s.Tokenizer, ","))
 	}


### PR DESCRIPTION
After running `CreateSchema` on a fresh database (no data or schema), everything works great. If I try to run `CreateSchema` a second time, I see messages like this:

```
2020/04/30 13:27:54 existing schema audit.audit_users, already defined as "audit.audit_users: uid @count @reverse .", trying to install "audit.audit_users: [uid] @count @reverse ."
```

The issue was that the `String` method on the existing schema was formatting list entries without brackets. This changed fixes that.