### PR TITLE
Fix TypeSchema.Marshal skipping passed in models.

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -138,7 +138,7 @@ func (t *TypeSchema) Marshal(parentType string, models ...interface{}) {
 
 		nodeType := GetNodeType(model)
 		if _, ok := t.Types[nodeType]; ok {
-			return
+			continue
 		}
 		if parentType == "" {
 			t.Types[nodeType] = make(SchemaMap)


### PR DESCRIPTION
Currently its possible for some of the models passed to `TypeSchema.Marshal` to be ignored. This happens when `Marshal` is called with a list of models and one of the models in the middle of the list is reachable from one of the models before it. In this case, once the model is reached again from the loop in the most parent call to `Marshal`, the function will `return` instead of `continue`ing. This causes the function to skip any models that come later in the list even though they may not have been visited yet.