### PR TITLE
rewrite mutate helpers to allow recursive unique checking

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,75 @@
+package dgman
+
+import "testing"
+
+type FlatStruct struct {
+	UID    string   `json:"uid,omitempty"`
+	Field1 string   `json:"field1,omitempty"`
+	Field2 int      `json:"field2,omitempty"`
+	Field3 bool     `json:"field3,omitempty"`
+	Field4 []int    `json:"field4,omitempty"`
+	Field5 []string `json:"field5,omitempty"`
+	DType  []string `json:"dgraph.type"`
+}
+
+func createFlatStruct() FlatStruct {
+	return FlatStruct{
+		Field1: "field 1",
+		Field2: 2,
+		Field3: true,
+		Field4: []int{1, 2, 3, 4},
+		Field5: []string{"test data 1", "test data 2", "test data 3", "test data 4"},
+	}
+}
+
+func BenchmarkMutateBasic(b *testing.B) {
+	c := newDgraphClient()
+	CreateSchema(c, FlatStruct{})
+	defer dropAll(c)
+
+	for n := 0; n < b.N; n++ {
+		data := createFlatStruct()
+
+		tx := NewTxn(c).CommitNow()
+		tx.MutateBasic(&data)
+	}
+}
+
+func BenchmarkMutate(b *testing.B) {
+	c := newDgraphClient()
+	CreateSchema(c, FlatStruct{})
+	defer dropAll(c)
+
+	for n := 0; n < b.N; n++ {
+		data := createTestUser()
+
+		tx := NewTxn(c).CommitNow()
+		tx.Mutate(&data)
+	}
+}
+
+func BenchmarkMutateBasicNested(b *testing.B) {
+	c := newDgraphClient()
+	CreateSchema(c, TestUser{})
+	defer dropAll(c)
+
+	for n := 0; n < b.N; n++ {
+		data := createTestUser()
+
+		tx := NewTxn(c).CommitNow()
+		tx.MutateBasic(&data)
+	}
+}
+
+func BenchmarkMutateNested(b *testing.B) {
+	c := newDgraphClient()
+	CreateSchema(c, TestUser{})
+	defer dropAll(c)
+
+	for n := 0; n < b.N; n++ {
+		data := createTestUser()
+
+		tx := NewTxn(c).CommitNow()
+		tx.Mutate(&data)
+	}
+}

--- a/delete_test.go
+++ b/delete_test.go
@@ -1,7 +1,6 @@
 package dgman
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,7 +70,7 @@ func TestDeleteFilter(t *testing.T) {
 
 	tx := NewTxn(c)
 
-	err := tx.Create(&users)
+	_, err := tx.Mutate(&users)
 	if err != nil {
 		t.Error(err)
 	}
@@ -104,9 +103,9 @@ func TestDeleteQuery(t *testing.T) {
 	school := School{
 		Name: "wildan's school",
 	}
-	tx := NewTxn(c)
+	tx := NewTxn(c).CommitNow()
 
-	err := tx.Create(&school, true)
+	_, err := tx.Mutate(&school)
 	if err != nil {
 		t.Error(err)
 	}
@@ -132,7 +131,7 @@ func TestDeleteQuery(t *testing.T) {
 
 	tx = NewTxn(c)
 
-	err = tx.Create(&users)
+	_, err = tx.Mutate(&users)
 	if err != nil {
 		t.Error(err)
 	}
@@ -194,7 +193,7 @@ func TestDeleteQueryNode(t *testing.T) {
 
 	tx := NewTxn(c)
 
-	err := tx.Create(&users)
+	_, err := tx.Mutate(&users)
 	if err != nil {
 		t.Error(err)
 	}
@@ -246,9 +245,9 @@ func TestDeleteEdge(t *testing.T) {
 		},
 	}
 
-	tx := NewTxn(c)
+	tx := NewTxn(c).CommitNow()
 
-	err := tx.Create(&schools, true)
+	_, err := tx.Mutate(&schools)
 	if err != nil {
 		t.Error(err)
 	}
@@ -262,7 +261,7 @@ func TestDeleteEdge(t *testing.T) {
 		Schools:  schools,
 	}
 
-	err = NewTxn(c).Create(&user, true)
+	_, err = NewTxn(c).CommitNow().Mutate(&user)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453
 	github.com/gin-gonic/gin v1.5.0
 	github.com/google/go-cmp v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.7
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1

--- a/interface.go
+++ b/interface.go
@@ -25,15 +25,14 @@ import (
 type TxnInterface interface {
 	Commit() error
 	Discard() error
+	CommitNow() *TxnContext
 	BestEffort() *TxnContext
 	Txn() *dgo.Txn
 	WithContext(context.Context)
 	Context() context.Context
-	Mutate(data interface{}, commitNow ...bool) error
-	Create(data interface{}, commitNow ...bool) error
-	Update(data interface{}, commitNow ...bool) error
-	Upsert(data interface{}, predicate string, commitNow ...bool) error
-	CreateOrGet(data interface{}, predicate string, commitNow ...bool) error
+	Mutate(data interface{}) ([]string, error)
+	MutateOrGet(data interface{}, predicates ...string) ([]string, error)
+	Upsert(data interface{}, predicates ...string) ([]string, error)
 	Delete(model interface{}, commitNow ...bool) *Deleter
 	Get(model interface{}) *Query
 }

--- a/mutate.go
+++ b/mutate.go
@@ -1,37 +1,24 @@
-/*
- * Copyright (C) 2018 Dolan and Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package dgman
 
 import (
-	"context"
-	"encoding/json"
+	stdjson "encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 
-	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/mitchellh/reflectwalk"
 	"github.com/pkg/errors"
 )
 
+type mutationOpCode uint8
+
 const (
-	dgraphTypePredicate = "dgraph.type"
+	mutationMutate mutationOpCode = iota
+	mutationMutateBasic
+	mutationMutateOrGet
+	mutationUpsert
 )
 
 // UniqueError returns the field and value that failed the unique node check
@@ -46,275 +33,280 @@ func (u *UniqueError) Error() string {
 	return fmt.Sprintf("%s with %s=%v already exists at uid=%s", u.NodeType, u.Field, u.Value, u.UID)
 }
 
-type mutateType struct {
-	vType     reflect.Type
-	value     *reflect.Value
-	schema    map[int]*Schema // maps struct index to dgraph schema
-	predIndex map[string]int  // maps predicate struct index
-	nodeType  string
+func isNull(x interface{}) bool {
+	return x == nil || reflect.DeepEqual(x, reflect.Zero(reflect.TypeOf(x)).Interface())
 }
 
 type node struct {
 	UID string `json:"uid"`
 }
 
-func reflectValue(model interface{}) (*reflect.Value, error) {
-	current := reflect.ValueOf(model)
-
-	if current.Kind() == reflect.Ptr && !current.IsNil() {
-		current = current.Elem()
-	}
-
-	if current.Kind() != reflect.Struct && current.Kind() != reflect.Slice && current.Kind() != reflect.Interface {
-		return nil, fmt.Errorf("model \"%s\" passed for schema is not a struct or slice", current.Type().Name())
-	}
-
-	// just use a slice, for unifying handling types
-	// slice with 1 length, the struct value as the first element
-	if current.Kind() == reflect.Struct {
-		slice := reflect.MakeSlice(reflect.SliceOf(reflect.PtrTo(current.Type())), 1, 1)
-		slice.Index(0).Set(current.Addr())
-		current = slice
-	}
-
-	return &current, nil
+type mutateType struct {
+	uidIndex int
+	schema   []*Schema // maps struct index to dgraph schema
+	nodeType string
 }
 
-func newMutateType(model interface{}) (*mutateType, error) {
-	mType := &mutateType{}
-	mType.schema = make(map[int]*Schema)
-	mType.predIndex = make(map[string]int)
-
-	vType, err := reflectType(model)
-	if err != nil {
-		return nil, err
-	}
-
-	mType.nodeType = getNodeType(vType)
-	mType.vType = vType
-
-	mType.value, err = reflectValue(model)
-	if err != nil {
-		return nil, err
-	}
-
-	numFields := vType.NumField()
-	for i := 0; i < numFields; i++ {
-		structField := vType.Field(i)
-
-		s, err := parseDgraphTag(&structField)
-		if err != nil {
-			return nil, err
-		}
-
-		mType.schema[i] = s
-		mType.predIndex[s.Predicate] = i
-	}
-
-	if err = mType.injectAlias(); err != nil {
-		return nil, err
-	}
-
-	return mType, nil
+func isUIDAlias(uid string) bool {
+	return strings.HasPrefix(uid, "_:")
 }
 
-func (m *mutateType) uidIndex() (int, error) {
-	index, ok := m.predIndex["uid"]
-	if !ok {
-		return -1, fmt.Errorf("uid field is not present in struct")
+func (m *mutateType) getID(v reflect.Value) string {
+	id := v.Field(m.uidIndex).String()
+	if isUIDAlias(id) {
+		return v.Field(m.uidIndex).String()[2:]
 	}
-	return index, nil
+	return id
 }
 
-func mutate(ctx context.Context, tx *dgo.Txn, data interface{}, commitNow ...bool) (*api.Response, error) {
-	optCommitNow := false
-	if len(commitNow) > 0 {
-		optCommitNow = commitNow[0]
+func newMutateType(numFields int) *mutateType {
+	return &mutateType{
+		schema: make([]*Schema, numFields),
 	}
-
-	out, err := marshalAndInjectType(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return tx.Mutate(ctx, &api.Mutation{
-		SetJson:   out,
-		CommitNow: optCommitNow,
-	})
 }
 
-// blankUID generates alias for blank uid from slice index
-func blankUID(index int) string {
-	return fmt.Sprintf("node-%d", index)
-}
-
-// injectAlias injects a node uid alias, for easier referencing nodes on mutate
-func (m *mutateType) injectAlias() error {
-	uidIndex, err := m.uidIndex()
-	if err != nil {
-		return err
-	}
-
-	n := m.value.Len()
-	for i := 0; i < n; i++ {
-		el := m.value.Index(i)
-		if el.Kind() == reflect.Ptr {
-			el = el.Elem()
-		}
-
-		if el.Field(uidIndex).Interface() == "" {
-			el.Field(uidIndex).SetString("_:" + blankUID(i))
-		}
-	}
-
-	return nil
+type preparedMutation struct {
+	queries   []string
+	condition string
+	value     reflect.Value
 }
 
 type mutation struct {
-	txn         *dgo.Txn
-	ctx         context.Context
-	update      bool
-	predicate   string
-	returnQuery bool
-	mType       *mutateType
-	commitNow   bool
+	data         interface{}
+	txn          *TxnContext
+	mutations    []preparedMutation
+	request      api.Request
+	queries      []string
+	typeCache    map[string]*mutateType
+	nodeCache    map[string]reflect.Value
+	refCache     map[string][]reflect.Value
+	opcode       mutationOpCode
+	upsertFields set
 }
 
-func newMutation(tx *TxnContext, data interface{}, commitNow ...bool) (*mutation, error) {
-	optCommitNow := false
-	if len(commitNow) > 0 {
-		optCommitNow = commitNow[0]
+func getCreatedUIDs(uidsMap map[string]string) []string {
+	uids := make([]string, 0, len(uidsMap))
+	for _, uid := range uidsMap {
+		uids = append(uids, uid)
+	}
+	return uids
+}
+
+func (m *mutation) mutate() ([]string, error) {
+	preHook := generateSchemaHook{mutation: m, skipTyping: true}
+	err := reflectwalk.Walk(m.data, preHook)
+	if err != nil {
+		return nil, errors.Wrap(err, "pre-mutation hook failed")
 	}
 
-	mType, err := newMutateType(data)
+	setJSON, err := json.Marshal(m.data)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal setJSON failed")
+	}
+
+	resp, err := m.txn.txn.Mutate(m.txn.ctx, &api.Mutation{
+		SetJson:   setJSON,
+		CommitNow: m.txn.commitNow,
+	})
+
+	postHook := setUIDHook{resp: resp}
+	err = reflectwalk.Walk(m.data, postHook)
+	if err != nil {
+		return nil, errors.Wrap(err, "post-mutation hook failed")
+	}
+
+	return getCreatedUIDs(resp.Uids), nil
+}
+
+func (m *mutation) do() ([]string, error) {
+	err := m.generateRequest()
+	if err != nil {
+		return nil, errors.Wrap(err, "generate request failed")
+	}
+
+	resp, err := m.txn.txn.Do(m.txn.ctx, &m.request)
+	if err != nil {
+		return nil, errors.Wrap(err, "do request failed")
+	}
+
+	err = m.processResponse(resp)
 	if err != nil {
 		return nil, err
 	}
 
-	return &mutation{txn: tx.txn, ctx: tx.ctx, mType: mType, commitNow: optCommitNow}, nil
+	return getCreatedUIDs(resp.Uids), nil
 }
 
-func (m *mutation) do() error {
-	req, err := m.generateRequest()
-	if err != nil {
-		return err
+func (m *mutation) generateRequest() error {
+	preMutationHooks := []reflectwalk.StructWalker{
+		generateSchemaHook{mutation: m},
+		generateMutationHook{m},
 	}
-
-	assigned, err := m.txn.Do(m.ctx, req)
-	if err != nil {
-		return err
-	}
-
-	if assigned.Json != nil {
-		if err = m.processQuery(assigned); err != nil {
-			return err
+	for i, hook := range preMutationHooks {
+		err := reflectwalk.Walk(m.data, hook)
+		if err != nil {
+			return errors.Wrapf(err, "pre-mutation %d hook failed", i)
 		}
 	}
 
-	// if not update save uid
-	if !m.update {
-		return m.saveUID(assigned.Uids)
+	for i, mutation := range m.mutations {
+		setJSON, err := json.Marshal(mutation.value.Interface())
+		if err != nil {
+			return errors.Wrapf(err, "marshal mutation value %d failed", i)
+		}
+
+		m.request.Mutations = append(m.request.Mutations, &api.Mutation{
+			SetJson: setJSON,
+			Cond:    mutation.condition,
+		})
+	}
+	queryString := strings.Join(m.queries, "\n")
+	if queryString != "" {
+		m.request.Query = fmt.Sprintf("{\n%s\n}", queryString)
 	}
 
 	return nil
 }
 
-func (m *mutation) generateRequest() (req *api.Request, err error) {
-	// reflected value must be a slice
-	len := m.mType.value.Len()
-	queries := make([]string, 0, len)
-	mutations := make([]*api.Mutation, len)
-	for i := 0; i < len; i++ {
-		v := m.mType.value.Index(i)
-
-		query, condition, err := m.generateQueryConditions(v.Interface(), i)
-		if err != nil {
-			return nil, err
-		}
-
-		if v.Kind() != reflect.Ptr {
-			v = v.Addr()
-		}
-
-		setJSON, err := marshalAndInjectType(v.Interface())
-		if err != nil {
-			return nil, err
-		}
-
-		queries = append(queries, query...)
-		mutations[i] = &api.Mutation{
-			Cond:    condition,
-			SetJson: setJSON,
+func setEdgeUID(target, edgeValue reflect.Value) {
+	if edgeValue.Kind() == reflect.Ptr {
+		edgeValue = edgeValue.Elem()
+	}
+	edgeType := edgeValue.Type()
+	newEdgeValuePtr := reflect.New(edgeType)
+	newEdgeValue := newEdgeValuePtr.Elem()
+	for i := 0; i < edgeValue.NumField(); i++ {
+		field := newEdgeValue.Field(i)
+		fieldType := edgeType.Field(i)
+		if predicate := getPredicate(&fieldType); predicate == predicateUid {
+			field.Set(edgeValue.Field(i))
+			break
 		}
 	}
 
-	queryString := strings.Join(queries, "\n")
-	if queryString != "" {
-		queryString = fmt.Sprintf("{\n%s\n}", queryString)
+	if target.Kind() == reflect.Ptr {
+		target.Set(newEdgeValuePtr)
+	} else {
+		target.Set(newEdgeValue)
 	}
-
-	return &api.Request{
-		Query:     queryString,
-		Mutations: mutations,
-		CommitNow: m.commitNow,
-	}, nil
 }
 
-func (m *mutation) generateQueryConditions(data interface{}, index int) (queries []string, condition string, err error) {
-	reflectVal := reflect.ValueOf(data)
-	if reflectVal.Kind() == reflect.Ptr {
-		reflectVal = reflectVal.Elem()
+// addToRefMap adds a reference to an edge, for easier updating reference to edge uids on upsert
+func (m *mutation) addToRefMap(edge reflect.Value) {
+	if edge.Kind() == reflect.Ptr {
+		edge = edge.Elem()
 	}
-
-	uidIndex, err := m.mType.uidIndex()
-	if err != nil {
-		return nil, "", err
+	edgeType := m.typeCache[edge.Type().String()]
+	uid := edge.Field(edgeType.uidIndex).String()
+	if isUIDAlias(uid) {
+		id := uid[2:]
+		m.refCache[id] = append(m.refCache[id], edge)
 	}
+}
 
-	numField := m.mType.vType.NumField()
-	var conditions []string
-	for schemaIndex := 0; schemaIndex < numField; schemaIndex++ {
-		field := reflectVal.Field(schemaIndex)
-		schema := m.mType.schema[schemaIndex]
-		// index refers to the slice index of data
-		queryIndex := fmt.Sprintf("q_%d_%d", index, schemaIndex)
-		uidListIndex := fmt.Sprintf("u_%d_%d", index, schemaIndex)
+// setRefsToUIDFunc sets reference uid alias in edges to UID func on upsert
+func (m *mutation) setRefsToUIDFunc(id, uidFunc string) {
+	refs := m.refCache[id]
+	for _, ref := range refs {
+		refType := m.typeCache[ref.Type().String()]
+		ref.Field(refType.uidIndex).SetString(uidFunc)
+	}
+}
 
-		if schema.Unique {
-			value := field.Interface()
-			if isNull(value) {
-				// only check unique if not null/zero value
-				continue
+func (m *mutation) generateMutation(v reflect.Value) error {
+	var (
+		queries    []string
+		conditions []string
+	)
+
+	vType := v.Type()
+	mutateType := m.typeCache[vType.String()]
+	id := mutateType.getID(v)
+	nodeValue := reflect.New(vType)
+	nodeValue = nodeValue.Elem()
+	uniqueCheck := true
+
+	for schemaIndex, schema := range mutateType.schema {
+		field := v.Field(schemaIndex)
+		if !field.CanInterface() {
+			// probably an unexported field, skip
+			continue
+		}
+
+		value := field.Interface()
+		if isNull(value) {
+			// empty/null values don't need be to processed
+			continue
+		}
+
+		// copy values to prevent mutating original data when setting edges
+		switch schema.Type {
+		case "[uid]":
+			edgesPlaceholder := reflect.MakeSlice(field.Type(), field.Len(), field.Cap())
+			edgesField := nodeValue.Field(schemaIndex)
+			edgesField.Set(edgesPlaceholder)
+			for i := 0; i < field.Len(); i++ {
+				setEdgeUID(edgesField.Index(i), field.Index(i))
+				if m.opcode == mutationUpsert {
+					m.addToRefMap(edgesField.Index(i))
+				}
 			}
+		case "uid":
+			edge := nodeValue.Field(schemaIndex)
+			setEdgeUID(edge, field)
+			if m.opcode == mutationUpsert {
+				m.addToRefMap(edge)
+			}
+		default:
+			if field.CanSet() {
+				nodeValue.Field(schemaIndex).Set(field)
+			}
+		}
 
+		queryIndex := fmt.Sprintf("q_%s_%d", id, schemaIndex)
+		uidListIndex := fmt.Sprintf("u_%s_%d", id, schemaIndex)
+		// check if current predicate is an upsert field specified by the user,
+		// when upsertFields is empty, any unique field can be upserted
+		isUpsertField := len(m.upsertFields) == 0 || m.upsertFields.Has(schema.Predicate)
+
+		if schema.Unique && uniqueCheck {
 			jsonValue, err := json.Marshal(value)
 			if err != nil {
-				return nil, "", errors.Wrapf(err, "marshal %v", value)
+				return errors.Wrapf(err, "marshal %v", value)
 			}
 
 			filter := fmt.Sprintf("eq(%s, %s)", schema.Predicate, jsonValue)
-			if m.update {
-				uid := reflectVal.Field(uidIndex).String()
+			if isUID(id) {
 				// if update make sure not unique checking the current node
-				filter = fmt.Sprintf("NOT uid(%s) AND %s", uid, filter)
+				filter = fmt.Sprintf("NOT uid(%s) AND %s", id, filter)
 			}
 
-			createOrGet := m.returnQuery && (m.predicate == "" || m.predicate == schema.Predicate)
-
 			queryFields := fmt.Sprintf("%s as uid", uidListIndex)
+			createOrGet := m.opcode == mutationMutateOrGet && isUpsertField
 			if createOrGet {
 				queryFields = fmt.Sprintf("%s\nexpand(_all_)", queryFields)
 			}
-			queries = append(queries, fmt.Sprintf("\t%s(func: type(%s), first: 1) @filter(%s) {\n%s\n}", queryIndex, m.mType.nodeType, filter, queryFields))
-			// on upsert field, allow mutation to continue, skip condition
-			if m.predicate != schema.Predicate || createOrGet {
-				conditions = append(conditions, fmt.Sprintf("eq(len(%s), 0)", uidListIndex))
-			}
-		}
 
-		if m.predicate != "" && m.predicate == schema.Predicate {
-			uidFunc := fmt.Sprintf("uid(%s)", uidListIndex)
-			reflectVal.Field(uidIndex).SetString(uidFunc)
+			queries = append(queries, fmt.Sprintf("\t%s(func: type(%s), first: 1) @filter(%s) {\n\t\t%s\n\t}", queryIndex, mutateType.nodeType, filter, queryFields))
+
+			// if upsert, allow mutation to continue, don't include condition to skip mutation
+			upsert := m.opcode == mutationUpsert && isUpsertField
+			if upsert {
+				uidFunc := fmt.Sprintf("uid(%s)", uidListIndex)
+				// update uid value to uid func
+				nodeValue.Field(mutateType.uidIndex).SetString(uidFunc)
+				v.Field(mutateType.uidIndex).SetString(uidFunc)
+				// update node cache to use uid func instead of uid alias
+				m.nodeCache[uidFunc] = v
+				delete(m.nodeCache, id)
+
+				m.setRefsToUIDFunc(id, uidFunc)
+				// don't continue unique checking on other fields, because uid can only be set once
+				uniqueCheck = false
+				continue
+			}
+
+			conditions = append(conditions, fmt.Sprintf("eq(len(%s), 0)", uidListIndex))
 		}
 	}
 
@@ -323,34 +315,42 @@ func (m *mutation) generateQueryConditions(data interface{}, index int) (queries
 		conditionString = fmt.Sprintf("@if(%s)", conditionString)
 	}
 
-	return queries, conditionString, nil
+	m.mutations = append([]preparedMutation{{
+		condition: conditionString,
+		value:     nodeValue,
+	}}, m.mutations...)
+	m.queries = append(m.queries, queries...)
+
+	return nil
 }
 
-func parseQueryIndex(queryIndex string) (sliceIndex int, schemaIndex int, err error) {
-	// queryIndex should have the format q_<sliceIndex>_<schemaIndex>
+func parseQueryIndex(queryIndex string) (id string, schemaIndex int, err error) {
+	// queryIndex should have the format q_<id>_<schemaIndex>
 	// e.g: q_0_2
 	queryIndexParts := strings.Split(queryIndex, "_")
 	if len(queryIndexParts) != 3 {
 		// hopefully no unrecognized queries found
-		return 0, 0, fmt.Errorf("unrecognized query")
+		return "", 0, fmt.Errorf("unrecognized query")
 	}
 
-	sliceIndex, err = strconv.Atoi(queryIndexParts[1])
-	if err != nil {
-		return 0, 0, errors.Wrapf(err, "sliceIndex atoi %s", queryIndex)
+	id = queryIndexParts[1]
+	isAlias := !(isUID(id) && isUIDFunc(id))
+	if isAlias {
+		id = "_:" + id
 	}
+
 	schemaIndex, err = strconv.Atoi(queryIndexParts[2])
 	if err != nil {
-		return 0, 0, errors.Wrapf(err, "schemaIndex atoi %s", queryIndex)
+		return "", 0, errors.Wrapf(err, "schemaIndex atoi %s", queryIndex)
 	}
 
-	return sliceIndex, schemaIndex, nil
+	return id, schemaIndex, nil
 }
 
-func (m *mutation) processQuery(assigned *api.Response) error {
-	var mapNodes map[string][]json.RawMessage
-	if err := json.Unmarshal(assigned.Json, &mapNodes); err != nil {
-		return errors.Wrapf(err, `unmarshal queryResponse "%s"`, assigned.Json)
+func (m *mutation) processJSONResponse(resp []byte) error {
+	var mapNodes map[string][]stdjson.RawMessage
+	if err := json.Unmarshal(resp, &mapNodes); err != nil {
+		return errors.Wrapf(err, `unmarshal queryResponse "%s"`, resp)
 	}
 
 	for queryIndex, msg := range mapNodes {
@@ -358,100 +358,211 @@ func (m *mutation) processQuery(assigned *api.Response) error {
 			continue
 		}
 
-		sliceIndex, schemaIndex, err := parseQueryIndex(queryIndex)
+		id, schemaIndex, err := parseQueryIndex(queryIndex)
 		if err != nil {
 			return err
 		}
 
-		schema := m.mType.schema[schemaIndex]
-		val := m.mType.value.Index(sliceIndex).Elem()
-		uidIndex, _ := m.mType.uidIndex()
+		nodeValue := m.nodeCache[id]
+		mutateType := m.typeCache[nodeValue.Type().String()]
+		schema := mutateType.schema[schemaIndex]
 
-		if m.returnQuery {
-			if m.predicate == "" || m.predicate == schema.Predicate {
-				if err := json.Unmarshal(msg[0], val.Addr().Interface()); err != nil {
-					return errors.Wrapf(err, "unmarshal query %s", queryIndex)
+		switch m.opcode {
+		case mutationMutate:
+			var node node
+			if err := json.Unmarshal(msg[0], &node); err != nil {
+				return errors.Wrapf(err, "unmarshal node %s", queryIndex)
+			}
+
+			queryUID := node.UID
+
+			// only return unique error if not updating the user specified node
+			// i.e: UID field is set
+			if nodeValue.Field(mutateType.uidIndex).String() != queryUID {
+				return &UniqueError{
+					NodeType: mutateType.nodeType,
+					Field:    schema.Predicate,
+					Value:    nodeValue.Field(schemaIndex).Interface(),
+					UID:      queryUID,
 				}
 			}
-			continue
-		}
+		case mutationMutateOrGet:
+			if len(m.upsertFields) > 0 && !m.upsertFields.Has(schema.Predicate) {
+				// not the specified field, skip
+				continue
+			}
 
-		var node node
-		if err := json.Unmarshal(msg[0], &node); err != nil {
-			return errors.Wrapf(err, "unmarshal node %s", queryIndex)
-		}
+			if err := json.Unmarshal(msg[0], nodeValue.Addr().Interface()); err != nil {
+				return errors.Wrapf(err, "unmarshal query %s", queryIndex)
+			}
+		case mutationUpsert:
+			if len(m.upsertFields) > 0 && !m.upsertFields.Has(schema.Predicate) {
+				// not the specified field, skip
+				continue
+			}
 
-		queryUID := node.UID
+			// set uid based on existing node query
+			var node node
+			if err := json.Unmarshal(msg[0], &node); err != nil {
+				return errors.Wrapf(err, "unmarshal node %s", queryIndex)
+			}
 
-		// set uid if upsert
-		if m.predicate != "" && m.predicate == schema.Predicate {
-			uidFunc := fmt.Sprintf("uid(u_%d_%d)", sliceIndex, schemaIndex)
-			uidField := val.Field(uidIndex)
+			uidFunc := fmt.Sprintf("uid(u_%s_%d)", id[2:], schemaIndex)
+			nodeValue = m.nodeCache[uidFunc]
+			queryUID := node.UID
+
+			uidField := nodeValue.Field(mutateType.uidIndex)
 			if uidFunc == uidField.String() {
-				// set the uid, if this is the matching upsert uid
 				uidField.SetString(queryUID)
 			}
+		}
+	}
+
+	return nil
+}
+
+func (m *mutation) processResponse(resp *api.Response) error {
+	if resp.Json != nil {
+		if err := m.processJSONResponse(resp.Json); err != nil {
+			return err
+		}
+	}
+
+	postHook := setUIDHook{resp: resp}
+	err := reflectwalk.Walk(m.data, postHook)
+	if err != nil {
+		return errors.Wrap(err, "post-mutation hook failed")
+	}
+
+	return nil
+}
+
+func setType(field reflect.StructField, fieldVal reflect.Value, nodeType string) error {
+	if !fieldVal.CanSet() {
+		return fmt.Errorf("dgraph.type not settable on %s.%s", nodeType, field.Name) // did you pass pointer?
+	}
+	switch field.Type.Kind() {
+	case reflect.String:
+		fieldVal.SetString(nodeType)
+	case reflect.Slice:
+		if field.Type.Elem().Kind() != reflect.String {
+			return errors.New(`"dgraph.type" field is not a slice of strings`)
+		}
+		fieldVal.Set(reflect.ValueOf([]string{nodeType}))
+	default:
+		return errors.New(`unsupported type for "dgraph.type" predicate`)
+	}
+
+	return nil
+}
+
+type generateSchemaHook struct {
+	mutation   *mutation
+	skipTyping bool
+}
+
+func (h generateSchemaHook) Struct(v reflect.Value) error {
+	vType := v.Type()
+	nodeType := vType.Name()
+	numFields := v.NumField()
+	mutateType, skipTyping := h.mutation.typeCache[nodeType]
+	if mutateType == nil {
+		mutateType = newMutateType(numFields)
+	}
+	if h.skipTyping {
+		skipTyping = true
+	}
+
+	for i := numFields - 1; i >= 0; i-- {
+		field := vType.Field(i)
+		fieldVal := v.Field(i)
+		fieldName := fmt.Sprintf("%s.%s", vType.Name(), field.Name)
+
+		predicate := getPredicate(&field)
+		switch predicate {
+		case predicateUid:
+			uid, err := genUID(field, fieldVal)
+			if err != nil {
+				return errors.Wrap(err, "gen UID failed")
+			}
+			if uid != "" {
+				// cache the struct value by its generated id
+				h.mutation.nodeCache[uid] = v
+			}
+			// for easier accessing the uid field
+			mutateType.uidIndex = i
+		case predicateDgraphType:
+			dgraphTag := field.Tag.Get(tagName)
+			if dgraphTag != "" {
+				nodeType = dgraphTag
+			}
+			if err := setType(field, fieldVal, nodeType); err != nil {
+				return errors.Wrapf(err, "set type failed on %s", fieldName)
+			}
+			mutateType.nodeType = nodeType
+		}
+
+		if skipTyping {
 			continue
 		}
-
-		// only return unique error if not updating the user specified node
-		// i.e: UID field is set
-		if val.Field(uidIndex).String() != queryUID {
-			return &UniqueError{
-				NodeType: m.mType.nodeType,
-				Field:    schema.Predicate,
-				Value:    val.Field(schemaIndex).Interface(),
-				UID:      queryUID,
-			}
+		schema, err := parseDgraphTag(&field)
+		if err != nil {
+			return errors.Wrapf(err, "parse dgraph tag failed on %s", fieldName)
 		}
+		mutateType.schema[i] = schema
 	}
+	if !skipTyping {
+		// cache the parsed type
+		h.mutation.typeCache[vType.String()] = mutateType
+	}
+
 	return nil
 }
 
-// saveUID saves the UID to the passed model, field with uid json tag
-func (m *mutation) saveUID(uids map[string]string) error {
-	val := m.mType.value
+func (h generateSchemaHook) StructField(f reflect.StructField, v reflect.Value) error {
+	return nil
+}
 
-	uidIndex, err := m.mType.uidIndex()
+type generateMutationHook struct {
+	mutation *mutation
+}
+
+func (h generateMutationHook) Struct(v reflect.Value) error {
+	return h.mutation.generateMutation(v)
+}
+
+func (h generateMutationHook) StructField(f reflect.StructField, v reflect.Value) error {
+	return nil
+}
+
+type setUIDHook struct {
+	mutation *mutation
+	resp     *api.Response
+}
+
+func (h setUIDHook) Struct(v reflect.Value) error {
+	return nil
+}
+
+func (h setUIDHook) StructField(f reflect.StructField, v reflect.Value) error {
+	err := setUIDs(f, v, h.resp.Uids)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "set UIDs failed")
 	}
-
-	// reflected value must be a slice
-	n := val.Len()
-	for i := 0; i < n; i++ {
-		el := val.Index(i)
-		if el.Kind() == reflect.Ptr {
-			el = el.Elem()
-		}
-
-		uidAlias := blankUID(i)
-		uid, exists := uids[uidAlias]
-		if exists {
-			el.Field(uidIndex).SetString(uid)
-		} else {
-			val := el.Field(uidIndex).String()
-			if val[0] == '_' {
-				// don't return node alias if uid not assigned
-				el.Field(uidIndex).SetString("")
-			}
-		}
-
-		if m.predicate != "" {
-			// if upsert created a new node
-			schemaIndex := m.mType.predIndex[m.predicate]
-			uidFunc := fmt.Sprintf("uid(u_%d_%d)", i, schemaIndex)
-			if uid, exists := uids[uidFunc]; exists {
-				el.Field(uidIndex).SetString(uid)
-			}
-		}
-	}
-
 	return nil
 }
 
-func isNull(x interface{}) bool {
-	return x == nil || reflect.DeepEqual(x, reflect.Zero(reflect.TypeOf(x)).Interface())
+func newMutation(txn *TxnContext, data interface{}) *mutation {
+	return &mutation{
+		data:      data,
+		txn:       txn,
+		nodeCache: make(map[string]reflect.Value),
+		typeCache: make(map[string]*mutateType),
+		refCache:  make(map[string][]reflect.Value),
+		request: api.Request{
+			CommitNow: txn.commitNow,
+		},
+	}
 }
 
 // SetTypes recursively walks all structures in data and sets the value of the
@@ -463,40 +574,27 @@ func SetTypes(data interface{}) error {
 	return reflectwalk.Walk(data, typeWalker{})
 }
 
-type typeWalker struct {
-	nodeType string
-}
+type typeWalker struct{}
 
 func (w typeWalker) Struct(v reflect.Value) error {
 	vType := v.Type()
 	nodeType := vType.Name()
+	numFields := v.NumField()
 
-	for i := v.NumField() - 1; i >= 0; i-- {
+	for i := numFields - 1; i >= 0; i-- {
 		field := vType.Field(i)
 		fieldVal := v.Field(i)
+		fieldName := fmt.Sprintf("%s.%s", vType.Name(), field.Name)
 
-		if getPredicate(&field) == dgraphTypePredicate {
+		predicate := getPredicate(&field)
+		if predicate == predicateDgraphType {
 			dgraphTag := field.Tag.Get(tagName)
 			if dgraphTag != "" {
 				nodeType = dgraphTag
 			}
-
-			if !fieldVal.CanSet() {
-				return fmt.Errorf("dgraph.type not settable on %s.%s", nodeType, field.Name) // did you pass pointer?
+			if err := setType(field, fieldVal, nodeType); err != nil {
+				return errors.Wrapf(err, "set type failed on %s", fieldName)
 			}
-			switch field.Type.Kind() {
-			case reflect.String:
-				fieldVal.SetString(nodeType)
-			case reflect.Slice:
-				if field.Type.Elem().Kind() != reflect.String {
-					return errors.New(`"dgraph.type" field is not a slice of strings`)
-				}
-				fieldVal.Set(reflect.ValueOf([]string{nodeType}))
-			default:
-				return errors.New(`unsupported type for "dgraph.type" predicate`)
-			}
-
-			break
 		}
 	}
 	return nil
@@ -504,11 +602,4 @@ func (w typeWalker) Struct(v reflect.Value) error {
 
 func (w typeWalker) StructField(f reflect.StructField, v reflect.Value) error {
 	return nil
-}
-
-func marshalAndInjectType(data interface{}) ([]byte, error) {
-	if err := SetTypes(data); err != nil {
-		return nil, errors.Wrap(err, "inject type")
-	}
-	return json.Marshal(data)
 }

--- a/mutate_test.go
+++ b/mutate_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Dolan and Contributors
+ * Copyright (C) 2020 Dolan and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,512 +17,257 @@
 package dgman
 
 import (
-	"context"
-	"encoding/json"
+	"sort"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type TestNode struct {
-	UID   string   `json:"uid,omitempty"`
-	Field string   `json:"field,omitempty"`
-	DType []string `json:"dgraph.type,omitempty"`
+type TestUser struct {
+	UID        string        `json:"uid,omitempty"`
+	Name       string        `json:"name,omitempty"`
+	Username   string        `json:"username,omitempty" dgraph:"index=term unique"`
+	Email      string        `json:"email,omitempty" dgraph:"index=term unique"`
+	Schools    []TestSchool  `json:"schools,omitempty" dgraph:"count"`
+	SchoolsPtr []*TestSchool `json:"schoolsPtr,omitempty" dgraph:"count"`
+	School     *TestSchool   `json:"school,omitempty"`
+	DType      []string      `json:"dgraph.type,omitempty"`
 }
 
-type TestCustomNode struct {
-	UID   string   `json:"uid,omitempty"`
-	Field string   `json:"field,omitempty"`
-	DType []string `json:"dgraph.type,omitempty" dgraph:"CustomNodeType"`
+type TestSchool struct {
+	UID        string       `json:"uid,omitempty"`
+	Name       string       `json:"name,omitempty"`
+	Identifier string       `json:"identifier,omitempty" dgraph:"index=term unique"`
+	EstYear    int          `json:"estYear,omitempty"`
+	Location   TestLocation `json:"location,omitempty"`
+	DType      []string     `json:"dgraph.type,omitempty"`
 }
 
-type TestUnique struct {
-	UID        string `json:"uid,omitempty"`
-	Name       string `json:"name,omitempty" dgraph:"index=term"`
-	Username   string `json:"username,omitempty" dgraph:"index=term unique"`
-	Email      string `json:"email,omitempty" dgraph:"index=term unique notnull"`
-	No         int    `json:"no,omitempty" dgraph:"index=int unique"`
-	unexported int
+type TestSchoolList []TestSchool
+
+func (l TestSchoolList) Len() int { return len(l) }
+
+func (l TestSchoolList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+
+type ByUID struct{ TestSchoolList }
+
+func (l ByUID) Less(i, j int) bool { return l.TestSchoolList[i].UID < l.TestSchoolList[j].UID }
+
+type TestLocation struct {
+	UID        string   `json:"uid,omitempty"`
+	LocationID string   `json:"locationId,omitempty" dgraph:"index=term unique"`
 	DType      []string `json:"dgraph.type,omitempty"`
 }
 
-type TestDTypeString struct {
-	UID   string `json:"uid,omitempty"`
-	Name  string `json:"name,omitempty"`
-	DType string `json:"dgraph.type,omitempty"`
-}
-
-type TestDTypeSlice struct {
-	UID          string                 `json:"uid,omitempty"`
-	Name         string                 `json:"name,omitempty"`
-	Edge         TestDTypeSliceInner    `json:"edge,omitempty"`
-	PtrEdge      *TestDTypeSliceInner   `json:"ptr_edge,omitempty"`
-	SliceEdge    []TestDTypeSliceInner  `json:"slice_edge,omitempty"`
-	SlicePtrEdge []*TestDTypeSliceInner `json:"slice_ptr_edge,omitempty"`
-	Time         *time.Time             `json:"time,omitempty"`
-	Times        []*time.Time           `json:"times,omitempty"`
-	DType        []string               `json:"dgraph.type,omitempty"`
-}
-
-type TestDTypeAnonymous struct {
-	Field string `json:"field,omitempty"`
-	TestDTypeSliceInner
-	DType []string `json:"dgraph.type,omitempty"`
-}
-
-type TestDTypeSliceInner struct {
-	UID   string   `json:"uid,omitempty"`
-	Name  string   `json:"name,omitempty"`
-	DType []string `json:"dgraph.type,omitempty"`
-}
-
-func Test_marshalAndInjectType(t *testing.T) {
-	type args struct {
-		data interface{}
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		{
-			name:    "should inject string in dgraph.type for struct",
-			args:    args{&TestDTypeString{Name: "wildan"}},
-			want:    []byte(`{"name":"wildan","dgraph.type":"TestDTypeString"}`),
-			wantErr: false,
-		},
-		{
-			name: "should inject slice of string in dgraph.type for struct",
-			args: args{&TestDTypeSlice{
-				Name:    "wildan",
-				Edge:    TestDTypeSliceInner{Name: "wildanjing"},
-				PtrEdge: &TestDTypeSliceInner{Name: "wildanjing2"},
-				SliceEdge: []TestDTypeSliceInner{
-					{Name: "wildanjing3"},
-				},
-				SlicePtrEdge: []*TestDTypeSliceInner{
-					{Name: "wildanjing4"},
-				},
-			}},
-			want:    []byte(`{"name":"wildan","edge":{"name":"wildanjing","dgraph.type":["TestDTypeSliceInner"]},"ptr_edge":{"name":"wildanjing2","dgraph.type":["TestDTypeSliceInner"]},"slice_edge":[{"name":"wildanjing3","dgraph.type":["TestDTypeSliceInner"]}],"slice_ptr_edge":[{"name":"wildanjing4","dgraph.type":["TestDTypeSliceInner"]}],"dgraph.type":["TestDTypeSlice"]}`),
-			wantErr: false,
-		},
-		{
-			name: "should inject slice of string in dgraph.type for slice",
-			args: args{&[]TestDTypeSlice{
-				{
-					Name:    "wildan",
-					Edge:    TestDTypeSliceInner{Name: "wildanjing"},
-					PtrEdge: &TestDTypeSliceInner{Name: "wildanjing2"},
-				},
-				{
-					Name:    "wildan",
-					Edge:    TestDTypeSliceInner{Name: "wildanjing"},
-					PtrEdge: &TestDTypeSliceInner{Name: "wildanjing2"},
-				},
-			}},
-			want:    []byte(`[{"name":"wildan","edge":{"name":"wildanjing","dgraph.type":["TestDTypeSliceInner"]},"ptr_edge":{"name":"wildanjing2","dgraph.type":["TestDTypeSliceInner"]},"dgraph.type":["TestDTypeSlice"]},{"name":"wildan","edge":{"name":"wildanjing","dgraph.type":["TestDTypeSliceInner"]},"ptr_edge":{"name":"wildanjing2","dgraph.type":["TestDTypeSliceInner"]},"dgraph.type":["TestDTypeSlice"]}]`),
-			wantErr: false,
-		},
-		{
-			name: "should parse anonymous structs with dgraph.type",
-			args: args{&TestDTypeAnonymous{
-				TestDTypeSliceInner: TestDTypeSliceInner{
-					Name: "wildan",
-				},
-			}},
-			want: []byte(`{"name":"wildan","dgraph.type":["TestDTypeAnonymous"]}`),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := marshalAndInjectType(tt.args.data)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("marshalAndInjectTypeV2() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			assert.Equal(t, string(tt.want), string(got))
-		})
-	}
-}
-
-func TestUniqueError_Error(t *testing.T) {
-	assert.EqualError(t, &UniqueError{NodeType: "User", Field: "username", Value: "wildanjing", UID: "0x1234"}, "User with username=wildanjing already exists at uid=0x1234")
-}
-
-func TestAddNode(t *testing.T) {
-	testData := &TestNode{Field: "test"}
-
-	c := newDgraphClient()
-	defer dropAll(c)
-
-	tx := NewTxn(c)
-
-	err := tx.Mutate(testData, true)
-	if err != nil {
-		t.Error(err)
-	}
-
-	tx = NewTxn(c)
-
-	query := `
-	{
-		data(func: type(TestNode)) {
-			uid
-			field
-		}
-	}
-	`
-
-	var result struct {
-		Data []*TestNode
-	}
-
-	resp, err := tx.Txn().Query(context.Background(), query)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if err := json.Unmarshal(resp.Json, &result); err != nil {
-		t.Error(err)
-	}
-
-	assert.Len(t, result.Data, 1)
-	assert.Equal(t, testData.UID, result.Data[0].UID)
-}
-
-func TestAddCustomNode(t *testing.T) {
-	testData := TestCustomNode{Field: "test"}
-
-	c := newDgraphClient()
-	defer dropAll(c)
-
-	tx := NewTxn(c)
-	err := tx.Mutate(&testData, true)
-	if err != nil {
-		t.Error(err)
-	}
-
-	tx = NewTxn(c)
-
-	query := `
-	query {
-		data(func: type(CustomNodeType)) {
-			uid
-			field
-		}
-	}
-	`
-
-	var result struct {
-		Data []TestCustomNode
-	}
-
-	resp, err := tx.Txn().Query(context.Background(), query)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if err := json.Unmarshal(resp.Json, &result); err != nil {
-		t.Error(err)
-	}
-
-	assert.Len(t, result.Data, 1)
-	assert.Equal(t, testData.UID, result.Data[0].UID)
-}
-
-func TestCreate(t *testing.T) {
-	testUnique := []TestUnique{
-		{
-			Name:     "H3h3",
-			Username: "wildan",
-			Email:    "wildan2711@gmail.com",
-			No:       1,
-		},
-		{
-			Name:     "PooDiePie",
-			Username: "wildansyah",
-			Email:    "wildansyah2711@gmail.com",
-			No:       2,
-		},
-		{
-			Name:     "Poopsie",
-			Username: "wildani",
-			Email:    "wildani@gmail.com",
-			No:       3,
-		},
-	}
-
-	c := newDgraphClient()
-	if _, err := CreateSchema(c, &TestUnique{}); err != nil {
-		t.Error(err)
-	}
-	defer dropAll(c)
-
-	tx := NewTxn(c)
-
-	err := tx.Create(&testUnique)
-	if err != nil {
-		t.Error(err)
-	}
-	if err := tx.Commit(); err != nil {
-		t.Error(err)
-	}
-
-	for _, el := range testUnique {
-		if el.UID == "" {
-			t.Error("uid is nil")
-		}
-	}
-
-	testDuplicate := []TestUnique{
-		{
-			Name:     "H3h3",
-			Username: "wildanjing",
-			Email:    "wildan2711@gmail.com",
-			No:       4,
-		},
-		{
-			Name:     "PooDiePie",
-			Username: "wildansyah",
-			Email:    "wildanodol2711@gmail.com",
-			No:       5,
-		},
-		{
-			Name:     "lalap",
-			Username: "lalap",
-			Email:    "lalap@gmail.com",
-			No:       3,
-		},
-	}
-
-	tx = NewTxn(c)
-
-	var duplicates []*UniqueError
-	for _, data := range testDuplicate {
-		err := tx.Create(&data)
-		if err != nil {
-			if uniqueError, ok := err.(*UniqueError); ok {
-				duplicates = append(duplicates, uniqueError)
-				continue
-			}
-			t.Error(err)
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		t.Error(err)
-	}
-
-	assert.Len(t, duplicates, 3)
-	assert.Equal(t, duplicates[0].Field, "email")
-	assert.Equal(t, duplicates[0].Value, "wildan2711@gmail.com")
-	assert.Equal(t, duplicates[1].Field, "username")
-	assert.Equal(t, duplicates[1].Value, "wildansyah")
-	assert.Equal(t, duplicates[2].Field, "no")
-	assert.Equal(t, duplicates[2].Value, 3)
-}
-
-func TestIsNull(t *testing.T) {
-	assert.True(t, isNull(""))
-	assert.True(t, isNull(0))
-	assert.True(t, isNull(false))
-	assert.True(t, isNull(nil))
-}
-
-func TestCreateNull(t *testing.T) {
-	c := newDgraphClient()
-	if _, err := CreateSchema(c, &TestUnique{}); err != nil {
-		t.Error(err)
-	}
-	defer dropAll(c)
-
-	testUniqueNull := TestUnique{
-		Name:     "H3h3",
-		Username: "",
-		Email:    "wildan2711@gmail.com",
-		No:       4,
-	}
-
-	if err := NewTxn(c).Create(&testUniqueNull, true); err != nil {
-		t.Error(err)
-	}
-
-	testUniqueNullAgain := TestUnique{
-		Name:     "tete",
-		Username: "",
-		Email:    "newemail@gmail.com",
-		No:       5,
-	}
-
-	if err := NewTxn(c).Create(&testUniqueNullAgain, true); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestUpdate(t *testing.T) {
-	c := newDgraphClient()
-	if _, err := CreateSchema(c, &TestUnique{}); err != nil {
-		t.Error(err)
-	}
-	defer dropAll(c)
-
-	testUniques := []TestUnique{
-		{
-			Name:     "haha",
-			Username: "",
-			Email:    "wildan2711@gmail.com",
-			No:       1,
-		},
-		{
-			Name:     "haha 2",
-			Username: "wildancok2711",
-			Email:    "wildancok2711@gmail.com",
-			No:       2,
-		},
-	}
-
-	tx := NewTxn(c)
-	if err := tx.Create(&testUniques, true); err != nil {
-		t.Error(err)
-	}
-
-	testUpdate := testUniques[0]
-	testUpdate.Username = "wildan2711"
-
-	tx = NewTxn(c)
-	if err := tx.Update(&testUpdate, true); err != nil {
-		t.Error(err)
-	}
-
-	testUpdate2 := testUniques[1]
-	testUpdate2.Username = "wildan2711"
-
-	tx = NewTxn(c)
-	if err := tx.Update(&testUpdate2, true); err != nil {
-		if uniqueErr, ok := err.(*UniqueError); ok {
-			if uniqueErr.Field != "username" {
-				t.Error("wrong unique field")
-			}
-		} else {
-			t.Error(err)
-		}
-	} else {
-		t.Error("must have unique error on username")
-	}
-}
-
-func TestUpsert(t *testing.T) {
-	c := newDgraphClient()
-	if _, err := CreateSchema(c, &TestUnique{}); err != nil {
-		t.Error(err)
-	}
-	defer dropAll(c)
-
-	testUpsert := &TestUnique{
-		Name:     "haha",
+func createTestUser() TestUser {
+	return TestUser{
+		Name:     "wildan",
 		Username: "wildan2711",
 		Email:    "wildan2711@gmail.com",
-		No:       1,
-	}
-
-	tx := NewTxn(c)
-	if err := tx.Upsert(testUpsert, "username", true); err != nil {
-		t.Error(err)
-	}
-
-	assert.NotZero(t, testUpsert.UID)
-
-	testUpsert2 := &TestUnique{
-		Name:     "wildanjing",
-		Username: "wildan2711",
-		Email:    "wildancok2711@gmail.com",
-		No:       2,
-	}
-
-	tx = NewTxn(c)
-	if err := tx.Upsert(testUpsert2, "username", true); err != nil {
-		t.Error(err)
-	}
-
-	assert.Equal(t, testUpsert.UID, testUpsert2.UID)
-
-	// check if the upsert succeeded
-	result := &TestUnique{}
-	if err := NewReadOnlyTxn(c).Get(result).UID(testUpsert.UID).Node(); err != nil {
-		t.Error(err)
-	}
-
-	assert.Equal(t, testUpsert2, result)
-
-	// make sure unique checking still holds
-	testCreate := &TestUnique{
-		Name:     "wildanjing",
-		Username: "wildancok2711",
-		Email:    "wildan2711@gmail.com",
-		No:       3,
-	}
-
-	if err := NewTxn(c).Create(testCreate, true); err != nil {
-		t.Error(err)
-	}
-
-	testUpsert3 := &TestUnique{
-		Name:     "wildanjing",
-		Username: "wildancok2711",
-		Email:    "wildancok2711@gmail.com",
-		No:       4,
-	}
-
-	tx = NewTxn(c)
-	if err := tx.Upsert(testUpsert3, "username", true); err != nil {
-		if uniqueErr, ok := err.(*UniqueError); ok {
-			if uniqueErr.Field != "email" {
-				t.Error("wrong unique field")
-			}
-		} else {
-			t.Error(err)
-		}
-	} else {
-		t.Error("must have unique error on email")
+		School: &TestSchool{
+			Name:       "BSS",
+			Identifier: "bss",
+			Location: TestLocation{
+				LocationID: "Malang",
+			},
+			EstYear: 1231,
+		},
+		SchoolsPtr: []*TestSchool{
+			{
+				Name:       "lab",
+				Identifier: "lab",
+				Location: TestLocation{
+					LocationID: "Malangian",
+				},
+				EstYear: 3131,
+			},
+		},
+		Schools: []TestSchool{
+			{
+				Name:       "Kensington",
+				Identifier: "kensington",
+				Location: TestLocation{
+					LocationID: "perth",
+				},
+				EstYear: 1234,
+			},
+			{
+				Name:       "Harvard",
+				Identifier: "harvard",
+				Location: TestLocation{
+					LocationID: "New York",
+				},
+				EstYear: 2013,
+			},
+		},
 	}
 }
 
-func TestCreateOrGet(t *testing.T) {
+func TestMutationMutateBasic(t *testing.T) {
 	c := newDgraphClient()
-	if _, err := CreateSchema(c, &TestUnique{}); err != nil {
+
+	_, err := CreateSchema(c, TestUser{})
+	if err != nil {
 		t.Error(err)
 	}
 	defer dropAll(c)
 
-	testUniques := []TestUnique{
-		{
-			Name:     "haha",
-			Username: "wilcok",
-			Email:    "wildan2711@gmail.com",
-			No:       1,
-		},
-		{
-			Name:     "haha 2",
-			Username: "wildancok2711",
-			Email:    "wildancok2711@gmail.com",
-			No:       2,
-		},
-	}
+	tx := NewTxn(c).CommitNow()
+	user := createTestUser()
 
-	tx := NewTxn(c)
-	if err := tx.Create(&testUniques, true); err != nil {
+	uids, err := tx.MutateBasic(&user)
+	if err != nil {
 		t.Error(err)
 	}
 
-	testCreateOrGet := testUniques[1]
-	testCreateOrGet.Email = "wildan2711@gmail.com"
+	assert.Len(t, uids, 9)
+}
 
-	tx = NewTxn(c)
-	if err := tx.CreateOrGet(&testCreateOrGet, "email", true); err != nil {
+func TestMutationMutate(t *testing.T) {
+	c := newDgraphClient()
+
+	_, err := CreateSchema(c, TestUser{})
+	if err != nil {
+		t.Error(err)
+	}
+	defer dropAll(c)
+
+	tx := NewTxn(c).CommitNow()
+	user := createTestUser()
+
+	uids, err := tx.Mutate(&user)
+	if err != nil {
 		t.Error(err)
 	}
 
-	assert.Equal(t, testUniques[0], testCreateOrGet)
+	assert.Len(t, uids, 9)
+
+	tx = NewTxn(c).CommitNow()
+	user = createTestUser()
+
+	_, err = tx.Mutate(&user)
+	assert.IsType(t, &UniqueError{}, err, err.Error())
+}
+
+func TestMutationUpdate(t *testing.T) {
+	c := newDgraphClient()
+
+	_, err := CreateSchema(c, TestUser{})
+	if err != nil {
+		t.Error(err)
+	}
+	defer dropAll(c)
+
+	tx := NewTxn(c).CommitNow()
+	user := createTestUser()
+
+	uids1, err := tx.Mutate(&user)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Len(t, uids1, 9)
+
+	// Update the fields, after uid has been injected after insert
+	tx = NewTxn(c).CommitNow()
+	user.Name = "Changed man"
+	user.School.Name = "Changed School"
+	user.Schools[0].Name = "Changed School 0"
+	user.Schools[1].Name = "Changed School 1"
+	user.SchoolsPtr[0].Name = "Changed School Ptr 1"
+
+	uids2, err := tx.Mutate(&user)
+	require.NoError(t, err)
+
+	assert.Len(t, uids2, 0)
+
+	sortByUID := ByUID{TestSchoolList: user.Schools}
+	sort.Sort(sortByUID)
+
+	// query the user, check if the user is correctly updated on upsert
+	tx = NewReadOnlyTxn(c)
+	var updatedUser TestUser
+	if err := tx.Get(&updatedUser).UID(user.UID).All(3).Node(); err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, user, updatedUser)
+}
+
+func TestMutationMutateOrGet(t *testing.T) {
+	c := newDgraphClient()
+
+	_, err := CreateSchema(c, TestUser{})
+	if err != nil {
+		t.Error(err)
+	}
+	defer dropAll(c)
+
+	tx := NewTxn(c).CommitNow()
+	user1 := createTestUser()
+
+	uids, err := tx.MutateOrGet(&user1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Len(t, uids, 9)
+
+	// try to create identical nodes from user1
+	// should not create any nodes, but return existing nodes
+	tx = NewTxn(c).CommitNow()
+	user2 := createTestUser()
+	uids, err = tx.MutateOrGet(&user2)
+	require.NoError(t, err)
+
+	assert.Len(t, uids, 0)
+	assert.Equal(t, user1, user2)
+}
+
+func TestMutationUpsert(t *testing.T) {
+	c := newDgraphClient()
+
+	_, err := CreateSchema(c, TestUser{})
+	if err != nil {
+		t.Error(err)
+	}
+	defer dropAll(c)
+
+	tx := NewTxn(c).CommitNow()
+	user1 := createTestUser()
+
+	uids1, err := tx.Upsert(&user1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Len(t, uids1, 9)
+
+	// try to create similar nodes from user1, but modified fields on non-unique fields
+	// should not create any nodes, but update existing nodes
+	tx = NewTxn(c).CommitNow()
+	user2 := createTestUser()
+	user2.Name = "Changed man"
+	user2.School.Name = "Changed School"
+	user2.Schools[0].Name = "Changed School 0"
+	user2.Schools[1].Name = "Changed School 1"
+	user2.SchoolsPtr[0].Name = "Changed School Ptr 1"
+
+	uids2, err := tx.Upsert(&user2)
+	require.NoError(t, err)
+
+	assert.Len(t, uids2, 0)
+
+	sortByUID := ByUID{TestSchoolList: user2.Schools}
+	sort.Sort(sortByUID)
+
+	// query the user, check if the user is correctly updated on upsert
+	tx = NewReadOnlyTxn(c)
+	var updatedUser TestUser
+	if err := tx.Get(&updatedUser).UID(user2.UID).All(3).Node(); err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, user2, updatedUser)
 }

--- a/mutate_uid.go
+++ b/mutate_uid.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2020 Dolan and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dgman
+
+import (
+	"fmt"
+	"reflect"
+	"sync/atomic"
+
+	"github.com/mitchellh/reflectwalk"
+)
+
+// overflow is OK
+var blankuid int32 = 0
+
+func blankUID() string {
+	i := atomic.AddInt32(&blankuid, 1)
+	return fmt.Sprintf("_:%d", i)
+}
+
+func genUID(f reflect.StructField, v reflect.Value) (string, error) {
+	if v.Kind() != reflect.String {
+		return "", nil
+	}
+
+	predicate := getPredicate(&f)
+	uid := v.String()
+
+	if predicate == "uid" {
+		if uid != "" {
+			// if uid already set, don't generate
+			return uid, nil
+		}
+		if !v.CanSet() {
+			return "", fmt.Errorf("cannot set uid")
+		}
+		uid = blankUID()
+		v.Set(reflect.ValueOf(uid))
+		return uid, nil
+	}
+	return "", nil
+}
+
+func setUIDs(f reflect.StructField, v reflect.Value, uids map[string]string) error {
+	if v.Kind() != reflect.String {
+		return nil
+	}
+
+	predicate := getPredicate(&f)
+	setUID := v.String()
+
+	if predicate == "uid" {
+		if !v.CanSet() {
+			return fmt.Errorf("cannot set %s/%s", predicate, setUID)
+		}
+		if isUIDAlias(setUID) {
+			uid, ok := uids[setUID[2:]]
+			if ok {
+				v.SetString(uid)
+			}
+		} else if isUIDFunc(setUID) {
+			uid, ok := uids[setUID]
+			if ok {
+				v.SetString(uid)
+			}
+		}
+	}
+	return nil
+}
+
+// SetUIDs recursively walks all structures in data and sets the value of the
+// `uid` struct field based on the uids map. A map of Uids is returned in Dgraph
+// mutate calls.
+func SetUIDs(data interface{}, uids map[string]string) error {
+	w := setUIDWalker{uids: uids}
+	return reflectwalk.Walk(data, w)
+}
+
+type setUIDWalker struct {
+	uids map[string]string
+}
+
+func (w setUIDWalker) Struct(v reflect.Value) error {
+	return nil
+}
+
+func (w setUIDWalker) StructField(f reflect.StructField, v reflect.Value) error {
+	return setUIDs(f, v, w.uids)
+}

--- a/query_test.go
+++ b/query_test.go
@@ -35,7 +35,7 @@ type TestModel struct {
 
 type TestEdge struct {
 	UID   string   `json:"uid"`
-	Level string   `json:"level"`
+	Level string   `json:"level,omitempty"`
 	DType []string `json:"dgraph.type,omitempty"`
 }
 
@@ -54,9 +54,9 @@ func TestGetByUID(t *testing.T) {
 		t.Error(err)
 	}
 
-	tx := NewTxn(c)
+	tx := NewTxn(c).CommitNow()
 
-	err = tx.Mutate(source, true)
+	_, err = tx.Mutate(source)
 	if err != nil {
 		t.Error(err)
 	}
@@ -86,9 +86,9 @@ func TestGetByFilter(t *testing.T) {
 	}
 	defer dropAll(c)
 
-	tx := NewTxn(c)
+	tx := NewTxn(c).CommitNow()
 
-	err := tx.Mutate(source, true)
+	_, err := tx.Mutate(source)
 	if err != nil {
 		t.Error(err)
 	}
@@ -138,7 +138,7 @@ func TestFind(t *testing.T) {
 
 	tx := NewTxn(c)
 
-	err := tx.Mutate(&source)
+	_, err := tx.Mutate(&source)
 	if err != nil {
 		t.Error(err)
 	}
@@ -146,10 +146,10 @@ func TestFind(t *testing.T) {
 
 	var dst []TestModel
 	tx = NewTxn(c)
-	if err := tx.Get(&dst).Query(`@filter(allofterms(name, $1)) { 
-		uid
-		expand(_all_)
-	}`, "wildan").Nodes(); err != nil {
+	if err := tx.Get(&dst).Query(`@filter(allofterms(name, $1)) {
+		 uid
+		 expand(_all_)
+	 }`, "wildan").Nodes(); err != nil {
 		t.Error(err)
 	}
 
@@ -171,7 +171,7 @@ func TestGetByQuery(t *testing.T) {
 
 	tx := NewTxn(c)
 
-	err := tx.Create(&source)
+	_, err := tx.Mutate(&source)
 	if err != nil {
 		t.Error(err)
 	}
@@ -182,7 +182,7 @@ func TestGetByQuery(t *testing.T) {
 	}
 
 	tx = NewTxn(c)
-	err = tx.Create(&source2)
+	_, err = tx.Mutate(&source2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -191,7 +191,7 @@ func TestGetByQuery(t *testing.T) {
 	source.Edges = []TestEdge{source2}
 
 	tx = NewTxn(c)
-	err = tx.Mutate(&source)
+	_, err = tx.Mutate(&source)
 	if err != nil {
 		t.Error(err)
 	}
@@ -217,6 +217,9 @@ func TestGetAllWithDepth(t *testing.T) {
 		Name:    "wildan anjing",
 		Address: "Beverly Hills",
 		Age:     17,
+		Edges: []TestEdge{{
+			Level: "one",
+		}},
 	}
 
 	c := newDgraphClient()
@@ -225,47 +228,27 @@ func TestGetAllWithDepth(t *testing.T) {
 	}
 	defer dropAll(c)
 
-	tx := NewTxn(c)
+	tx := NewTxn(c).CommitNow()
 
-	err := tx.Create(&source)
+	uids, err := tx.Mutate(&source)
 	if err != nil {
 		t.Error(err)
 	}
-	tx.Commit()
-
-	source2 := TestEdge{
-		Level: "one",
-	}
-
-	tx = NewTxn(c)
-	err = tx.Create(&source2)
-	if err != nil {
-		t.Error(err)
-	}
-	tx.Commit()
-
-	source.Edges = []TestEdge{source2}
-
-	tx = NewTxn(c)
-	err = tx.Mutate(&source)
-	if err != nil {
-		t.Error(err)
-	}
-	tx.Commit()
+	assert.Len(t, uids, 2)
 
 	var dst TestModel
 	tx = NewTxn(c)
 	q := tx.Get(&dst).
 		Filter(`allofterms(name, "wildan")`).
-		All(1)
+		All(2)
 	if err := q.Node(); err != nil {
 		t.Error(err)
 	}
 
-	assert.Equal(t, dst.UID, source.UID)
+	assert.Equal(t, source.UID, dst.UID)
 	assert.Len(t, dst.Edges, 1)
-	assert.Equal(t, dst.Edges[0].UID, source2.UID)
-	assert.Equal(t, dst.Edges[0].Level, source2.Level)
+	assert.Equal(t, source.Edges[0].UID, dst.Edges[0].UID)
+	assert.Equal(t, source.Edges[0].Level, dst.Edges[0].Level)
 }
 
 func TestPagination(t *testing.T) {
@@ -284,7 +267,7 @@ func TestPagination(t *testing.T) {
 	defer dropAll(c)
 
 	tx := NewTxn(c)
-	err := tx.Mutate(&models)
+	_, err := tx.Mutate(&models)
 	if err != nil {
 		t.Error(err)
 	}
@@ -341,7 +324,7 @@ func TestOrder(t *testing.T) {
 
 	tx := NewTxn(c)
 
-	err := tx.Create(&models)
+	_, err := tx.Mutate(&models)
 	if err != nil {
 		t.Error(err)
 	}
@@ -402,8 +385,8 @@ func TestQueryBlock(t *testing.T) {
 		})
 	}
 
-	tx := NewTxn(c)
-	if err := tx.Create(&models, true); err != nil {
+	tx := NewTxn(c).CommitNow()
+	if _, err := tx.Mutate(&models); err != nil {
 		t.Error(err)
 		return
 	}
@@ -455,8 +438,8 @@ func TestGetNodesAndCount(t *testing.T) {
 		})
 	}
 
-	tx := NewTxn(c)
-	if err := tx.Create(&models, true); err != nil {
+	tx := NewTxn(c).CommitNow()
+	if _, err := tx.Mutate(&models); err != nil {
 		t.Error(err)
 		return
 	}

--- a/schema.go
+++ b/schema.go
@@ -18,7 +18,7 @@ package dgman
 
 import (
 	"context"
-	"encoding/json"
+
 	"fmt"
 	"log"
 	"reflect"
@@ -30,7 +30,11 @@ import (
 	"github.com/dgraph-io/dgo/v200"
 )
 
-const tagName = "dgraph"
+const (
+	tagName             = "dgraph"
+	predicateDgraphType = "dgraph.type"
+	predicateUid        = "uid"
+)
 
 type rawSchema struct {
 	Predicate  string
@@ -171,7 +175,7 @@ func (t *TypeSchema) Marshal(parentType string, models ...interface{}) {
 			schema, exists := t.Schema[s.Predicate]
 			parse := s.Predicate != "" &&
 				s.Predicate != "uid" && // don't parse uid
-				s.Predicate != dgraphTypePredicate && // don't parse dgraph.type
+				s.Predicate != predicateDgraphType && // don't parse dgraph.type
 				!strings.Contains(s.Predicate, "|") && // don't parse facet
 				s.Predicate[0] != '~' // don't parse reverse edge
 			if parse {
@@ -448,7 +452,7 @@ func getNodeType(dataType reflect.Type) string {
 		field := dataType.Field(i)
 		predicate := getPredicate(&field)
 
-		if predicate == dgraphTypePredicate {
+		if predicate == predicateDgraphType {
 			dgraphTag := field.Tag.Get(tagName)
 			if dgraphTag != "" {
 				nodeType = dgraphTag

--- a/schema_test.go
+++ b/schema_test.go
@@ -125,15 +125,15 @@ func TestMarshalSchema(t *testing.T) {
 }
 
 func TestGetNodeType(t *testing.T) {
-	nodeTypeStruct := GetNodeType(TestNode{})
-	nodeTypePtr := GetNodeType(&TestNode{})
-	nodeTypeSlice := GetNodeType([]TestNode{})
-	nodeTypeSlicePtr := GetNodeType([]*TestNode{})
+	nodeTypeStruct := GetNodeType(User{})
+	nodeTypePtr := GetNodeType(&User{})
+	nodeTypeSlice := GetNodeType([]User{})
+	nodeTypeSlicePtr := GetNodeType([]*User{})
 
-	assert.Equal(t, "TestNode", nodeTypeStruct)
-	assert.Equal(t, "TestNode", nodeTypePtr)
-	assert.Equal(t, "TestNode", nodeTypeSlice)
-	assert.Equal(t, "TestNode", nodeTypeSlicePtr)
+	assert.Equal(t, "User", nodeTypeStruct)
+	assert.Equal(t, "User", nodeTypePtr)
+	assert.Equal(t, "User", nodeTypeSlice)
+	assert.Equal(t, "User", nodeTypeSlicePtr)
 }
 
 func TestCreateSchema(t *testing.T) {


### PR DESCRIPTION
Major changes:
- Use [https://github.com/mitchellh/reflectwalk] to simplify traversing structs
- Recursive UID injection on mutate, fixes #46
- Recursive unique checking, fixes #37 
- Removed `Create` and `Update` mutate helpers. `Mutate` can accommodate both by checking if the `uid` field is an actual hex uid.
- Use `CommitNow()` method instead of passing as boolean to mutate helpers.