### PR TITLE
Delete helper rewrite to use upsert blocks

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Dolan and Contributors
+ * Copyright (C) 2020 Dolan and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,202 +18,127 @@ package dgman
 
 import (
 	"bytes"
-	"context"
 
 	"github.com/dgraph-io/dgo/v200/protos/api"
-
-	"github.com/dgraph-io/dgo/v200"
 	"github.com/pkg/errors"
 )
 
-type Deleter struct {
-	ctx       context.Context
-	tx        *dgo.Txn
-	model     interface{}
-	q         *Query
-	commitNow bool
+// DeleteCond is a struct to past delete conditions on specified uids
+type DeleteCond struct {
+	Cond string
+	Uids []string
 }
 
-// Query defines the query portion other than the root function for deletion
-func (d *Deleter) Query(query string, params ...interface{}) *Deleter {
-	d.q.query = parseQueryWithParams(query, params)
-	return d
+type DeleteQuery struct {
+	query  *QueryBlock
+	result []byte
 }
 
-// Filter defines a query filter, return predicates at the first depth
-func (d *Deleter) Filter(filter string, params ...interface{}) *Deleter {
-	d.q.filter = parseQueryWithParams(filter, params)
-	return d
+// Scan will unmarshal the delete query result into the passed interface{},
+// if nothing is passed, it will be unmarshaled to the individual query models.
+func (d DeleteQuery) Scan(dst ...interface{}) error {
+	return d.query.scan(d.result, dst...)
 }
 
-// UID returns the node with the specified uid
-func (d *Deleter) UID(uid string) *Deleter {
-	d.q.uid = uid
-	return d
-}
-
-// All returns expands all predicates, with a depth parameter that specifies
-// how deep should edges be expanded
-func (d *Deleter) All(depthParam ...int) *Deleter {
-	d.q.All(depthParam...)
-	return d
-}
-
-// Vars specify the GraphQL variables to be passed on the query,
-// by specifying the function definition of vars, and variable map.
-// Example funcDef: getUserByEmail($email: string, $age: number)
-func (d *Deleter) Vars(funcDef string, vars map[string]string) *Deleter {
-	d.q.paramString = funcDef
-	d.q.vars = vars
-	return d
-}
-
-// RootFunc modifies the dgraph query root function, if not set,
-// the default is "type(NodeType)"
-func (d *Deleter) RootFunc(rootFunc string) *Deleter {
-	d.q.rootFunc = rootFunc
-	return d
-}
-
-func (d *Deleter) First(n int) *Deleter {
-	d.q.first = n
-	return d
-}
-
-func (d *Deleter) Offset(n int) *Deleter {
-	d.q.offset = n
-	return d
-}
-
-func (d *Deleter) After(uid string) *Deleter {
-	d.q.after = uid
-	return d
-}
-
-func (d *Deleter) OrderAsc(clause string) *Deleter {
-	d.q.order = append(d.q.order, order{clause: clause})
-	return d
-}
-
-func (d *Deleter) OrderDesc(clause string) *Deleter {
-	d.q.order = append(d.q.order, order{descending: true, clause: clause})
-	return d
-}
-
-// Edge delete edges of a node of specified edge predicate, if no edgeUIDs specified,
-// delete all edges
-func (d *Deleter) Edge(uid, edgePredicate string, edgeUIDs ...string) error {
-	var buffer bytes.Buffer
-
-	buffer.WriteString(`{"uid": "`)
-	buffer.WriteString(uid)
-	buffer.WriteString(`", "`)
-	buffer.WriteString(edgePredicate)
-	buffer.WriteString(`": `)
-
-	if len(edgeUIDs) == 0 {
-		// if no uids specified, delete all edges
-		buffer.WriteString(`null`)
-	} else {
-		buffer.WriteByte('[')
-		for _, edgeUID := range edgeUIDs {
-			buffer.WriteString(`{"uid": "`)
-			buffer.WriteString(edgeUID)
-			buffer.WriteString(`"}`)
+func (d *TxnContext) deleteQuery(query *QueryBlock, uids ...string) (DeleteQuery, error) {
+	var nQuads bytes.Buffer
+	for _, uid := range uids {
+		if isUID(uid) {
+			nQuads.WriteString("<")
+			nQuads.WriteString(uid)
+			nQuads.WriteString("> * * .\n")
+		} else {
+			nQuads.WriteString("uid(")
+			nQuads.WriteString(uid)
+			nQuads.WriteString(") * * .\n")
 		}
-		buffer.WriteByte(']')
 	}
-
-	buffer.WriteByte('}')
-
-	_, err := d.tx.Mutate(d.ctx, &api.Mutation{DeleteJson: buffer.Bytes(), CommitNow: d.commitNow})
-	return err
-}
-
-// Node deletes the first single root node from the query
-// including edge nodes that may be specified on the query
-func (d *Deleter) Node() (uids []string, err error) {
-	d.q.first = 1
-
-	result, err := d.q.executeQuery()
+	req := &api.Request{
+		Query: query.String(),
+		Mutations: []*api.Mutation{{
+			DelNquads: nQuads.Bytes(),
+		}},
+		CommitNow: d.commitNow,
+	}
+	resp, err := d.txn.Do(d.ctx, req)
 	if err != nil {
-		return nil, errors.Wrap(err, "exec")
+		return DeleteQuery{}, errors.Wrap(err, "request failed")
 	}
-
-	model := make(map[string]interface{})
-	if err := d.q.node(result, &model); err != nil {
-		return nil, errors.Wrap(err, "parse query")
-	}
-
-	traverseUIDs(&uids, model)
-
-	return uids, d.deleteUids(uids)
+	return DeleteQuery{
+		query:  query,
+		result: resp.Json,
+	}, nil
 }
 
-// Nodes deletes all nodes matching the delete query
-// including edge nodes that may be specified on the query
-func (d *Deleter) Nodes() (uids []string, err error) {
-	result, err := d.q.executeQuery()
+func (d *TxnContext) deleteQueryCondition(query *QueryBlock, conds ...DeleteCond) (DeleteQuery, error) {
+	req := &api.Request{
+		Query:     query.String(),
+		CommitNow: d.commitNow,
+	}
+	for _, cond := range conds {
+		var nQuads bytes.Buffer
+		for _, uid := range cond.Uids {
+			if isUID(uid) {
+				nQuads.WriteString("<")
+				nQuads.WriteString(uid)
+				nQuads.WriteString("> * * .\n")
+			} else {
+				nQuads.WriteString("uid(")
+				nQuads.WriteString(uid)
+				nQuads.WriteString(") * * .\n")
+			}
+		}
+		req.Mutations = append(req.Mutations, &api.Mutation{
+			Cond:      cond.Cond,
+			DelNquads: nQuads.Bytes(),
+		})
+	}
+	resp, err := d.txn.Do(d.ctx, req)
 	if err != nil {
-		return nil, err
+		return DeleteQuery{}, errors.Wrap(err, "request failed")
 	}
-
-	var model []map[string]interface{}
-	if err := d.q.nodes(result, &model); err != nil {
-		return nil, err
-	}
-
-	for _, m := range model {
-		traverseUIDs(&uids, m)
-	}
-
-	return uids, d.deleteUids(uids)
+	return DeleteQuery{
+		query:  query,
+		result: resp.Json,
+	}, nil
 }
 
-func (d *Deleter) deleteUids(uids []string) error {
-	uidsJSON := generateUidsJSON(uids)
-	_, err := d.tx.Mutate(d.ctx, &api.Mutation{
-		DeleteJson: uidsJSON,
-		CommitNow:  d.commitNow,
+func (d *TxnContext) deleteNode(uids ...string) error {
+	var nQuads bytes.Buffer
+	for _, uid := range uids {
+		nQuads.WriteString("<")
+		nQuads.WriteString(uid)
+		nQuads.WriteString("> * * .\n")
+	}
+	_, err := d.txn.Mutate(d.ctx, &api.Mutation{
+		DelNquads: nQuads.Bytes(),
+		CommitNow: d.commitNow,
 	})
-
 	return err
 }
 
-func generateUidsJSON(uids []string) []byte {
-	var b bytes.Buffer
-
-	b.WriteByte('[')
-	for i, uid := range uids {
-		b.WriteString(`{"uid":"`)
-		b.WriteString(uid)
-		b.WriteString(`"}`)
-
-		if i != len(uids)-1 {
-			b.WriteByte(',')
+func (d *TxnContext) deleteEdge(uid string, predicate string, edgeUIDs ...string) error {
+	var nQuads bytes.Buffer
+	if len(edgeUIDs) > 0 {
+		for _, edgeUID := range edgeUIDs {
+			nQuads.WriteRune('<')
+			nQuads.WriteString(uid)
+			nQuads.WriteString("> <")
+			nQuads.WriteString(predicate)
+			nQuads.WriteString("> <")
+			nQuads.WriteString(edgeUID)
+			nQuads.WriteString("> .\n")
 		}
+	} else {
+		nQuads.WriteRune('<')
+		nQuads.WriteString(uid)
+		nQuads.WriteString("> <")
+		nQuads.WriteString(predicate)
+		nQuads.WriteString("> * .\n")
 	}
-	b.WriteByte(']')
-	return b.Bytes()
-}
-
-func traverseUIDs(uids *[]string, model map[string]interface{}) {
-	for predicate, val := range model {
-		switch v := val.(type) {
-		case []interface{}:
-			for _, node := range v {
-				if v2, ok := node.(map[string]interface{}); ok {
-					traverseUIDs(uids, v2)
-				}
-			}
-		case string:
-			if predicate == "uid" {
-				*uids = append(*uids, val.(string))
-			}
-		}
-	}
-}
-
-func (d *Deleter) String() string {
-	return d.q.String()
+	_, err := d.txn.Mutate(d.ctx, &api.Mutation{
+		DelNquads: nQuads.Bytes(),
+		CommitNow: d.commitNow,
+	})
+	return err
 }

--- a/interface.go
+++ b/interface.go
@@ -33,7 +33,10 @@ type TxnInterface interface {
 	Mutate(data interface{}) ([]string, error)
 	MutateOrGet(data interface{}, predicates ...string) ([]string, error)
 	Upsert(data interface{}, predicates ...string) ([]string, error)
-	Delete(model interface{}, commitNow ...bool) *Deleter
+	Delete(query *QueryBlock, uids ...string) (DeleteQuery, error)
+	DeleteCond(query *QueryBlock, conds ...DeleteCond) (DeleteQuery, error)
+	DeleteNode(uids ...string) error
+	DeleteEdge(uid string, predicate string, uids ...string) error
 	Get(model interface{}) *Query
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -146,10 +146,10 @@ func TestFind(t *testing.T) {
 
 	var dst []TestModel
 	tx = NewTxn(c)
-	if err := tx.Get(&dst).Query(`@filter(allofterms(name, $1)) {
+	if err := tx.Get(&dst).Filter("allofterms(name, $1)", "wildan").Query(`{
 		 uid
 		 expand(_all_)
-	 }`, "wildan").Nodes(); err != nil {
+	 }`).Nodes(); err != nil {
 		t.Error(err)
 	}
 
@@ -404,7 +404,7 @@ func TestQueryBlock(t *testing.T) {
 
 	query := tx.
 		Query(
-			NewQuery().As("result").Var().Type(&TestModel{}).Filter(`anyofterms(name, $name)`),
+			NewQuery().As("result").Var().Model(&TestModel{}).Filter(`anyofterms(name, $name)`),
 			NewQuery().Name("paged").UID("result").First(2).Offset(2).All(1),
 			NewQuery().Name("pageInfo").UID("result").Query(`{ total: count(uid) }`),
 		).


### PR DESCRIPTION
Delete helper rewrite to use upsert blocks:
- Use QueryBlocks to use query in delete.
- `Query` to delete nodes by query.
- `QueryCond` to delete nodes by query with a condition.
- `QueryNode` to delete nodes by uid.
- `QueryEdge` to delete edges of a node.