### PR TITLE
Fix nested unique check to prevent orphaned children

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dolan-in/dgman/v2
 
 require (
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453
-	github.com/dolan-in/reflectwalk v1.0.2-0.20201231054028-585ac6716cbe // indirect
+	github.com/dolan-in/reflectwalk v1.0.2-0.20201231054028-585ac6716cbe
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.7
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dolan-in/dgman/v2
 
 require (
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453
-	github.com/dolan-in/reflectwalk v0.0.0-00010101000000-000000000000
+	github.com/dolan-in/reflectwalk v1.0.2-0.20201231054028-585ac6716cbe // indirect
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.7
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
@@ -18,5 +18,3 @@ require (
 )
 
 go 1.14
-
-replace github.com/dolan-in/reflectwalk => ../reflectwalk

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,11 @@ module github.com/dolan-in/dgman/v2
 
 require (
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453
+	github.com/dolan-in/reflectwalk v0.0.0-00010101000000-000000000000
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.7
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 	github.com/kr/pretty v0.2.0 // indirect
-	github.com/mitchellh/reflectwalk v1.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
@@ -18,3 +18,5 @@ require (
 )
 
 go 1.14
+
+replace github.com/dolan-in/reflectwalk => ../reflectwalk

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
-github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453 h1:DTgOrw91nMIukDm/WEvdobPLl0LgeDd/JE66+24jBks=
 github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453/go.mod h1:Co+FwJrnndSrPORO8Gdn20dR7FPTfmXr0W/su0Ve/Ig=
+github.com/dolan-in/reflectwalk v1.0.2-0.20201231054028-585ac6716cbe h1:F2WtVoEnV4WK2l653VCjRPItWMUuNuY3jm/e990jEkI=
+github.com/dolan-in/reflectwalk v1.0.2-0.20201231054028-585ac6716cbe/go.mod h1:Y9TyDkSL5jQ18ZnDaSxOdCUhbb5SCeamqYFQ7LYxxFs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=

--- a/query.go
+++ b/query.go
@@ -252,10 +252,7 @@ func (q *Query) UID(uid string) *Query {
 	return q
 }
 
-func expandPredicate(depth int) string {
-	var buffer strings.Builder
-
-	buffer.WriteString("{\n\t\tuid\n\t\tdgraph.type\n\t\texpand(_all_)")
+func expandPredicate(buffer *strings.Builder, depth int) {
 	for i := 0; i < depth; i++ {
 		tabs := strings.Repeat("\t", i+1)
 		buffer.WriteString(" {\n\t\t")
@@ -272,6 +269,13 @@ func expandPredicate(depth int) string {
 		buffer.WriteString(tabs)
 		buffer.WriteString("}")
 	}
+}
+
+func expandAll(depth int) string {
+	var buffer strings.Builder
+
+	buffer.WriteString("{\n\t\tuid\n\t\tdgraph.type\n\t\texpand(_all_)")
+	expandPredicate(&buffer, depth)
 	buffer.WriteString("\n\t}")
 
 	return buffer.String()
@@ -285,7 +289,7 @@ func (q *Query) All(depthParam ...int) *Query {
 		depth = depthParam[0]
 	}
 
-	q.query = expandPredicate(depth)
+	q.query = expandAll(depth)
 	return q
 }
 

--- a/query.go
+++ b/query.go
@@ -376,7 +376,9 @@ func (q *Query) node(jsonData []byte, dst interface{}) error {
 	// remove prefix and the ending array closer ']'
 	dataBytes := jsonData[dataPrefixLen : dataLen-2]
 
-	if len(dataBytes) == 0 {
+	// if dgraph.type predicate not found, must be empty node
+	hasType := strings.Contains(string(dataBytes), predicateDgraphType)
+	if len(dataBytes) == 0 || !hasType {
 		return ErrNodeNotFound
 	}
 
@@ -524,17 +526,9 @@ func (q *Query) generateQuery(queryBuf *strings.Builder) {
 	queryBuf.WriteString(") ")
 	// END ROOT FUNCTION
 
-	// make sure deleted nodes are not returned
-	typeIsNotNull := "has(dgraph.type)"
 	if q.filter != "" {
 		queryBuf.WriteString("@filter(")
-		queryBuf.WriteString(typeIsNotNull)
-		queryBuf.WriteString(" AND ")
 		queryBuf.WriteString(q.filter)
-		queryBuf.WriteString(") ")
-	} else {
-		queryBuf.WriteString("@filter(")
-		queryBuf.WriteString(typeIsNotNull)
 		queryBuf.WriteString(") ")
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -456,7 +456,7 @@ func TestGetNodesAndCount(t *testing.T) {
 	assert.Equal(t, 5, count)
 }
 
-func TestExpandPredicate(t *testing.T) {
+func TestExpandAll(t *testing.T) {
 	expectedDepthZero := `{
 		uid
 		dgraph.type
@@ -487,9 +487,9 @@ func TestExpandPredicate(t *testing.T) {
 		}
 	}`
 
-	assert.Equal(t, expectedDepthZero, expandPredicate(0))
-	assert.Equal(t, expectedDepthOne, expandPredicate(1))
-	assert.Equal(t, expectedDepthTwo, expandPredicate(2))
+	assert.Equal(t, expectedDepthZero, expandAll(0))
+	assert.Equal(t, expectedDepthOne, expandAll(1))
+	assert.Equal(t, expectedDepthTwo, expandAll(2))
 }
 
 func Test_parseQueryWithParams(t *testing.T) {

--- a/schema.go
+++ b/schema.go
@@ -34,6 +34,9 @@ const (
 	tagName             = "dgraph"
 	predicateDgraphType = "dgraph.type"
 	predicateUid        = "uid"
+
+	schemaUid     = "uid"
+	schemaUidList = "[uid]"
 )
 
 type rawSchema struct {


### PR DESCRIPTION
Fix nested unique check to prevent orphaned children on nested struct, when a superstruct failed the unique check.