### PR TITLE
Fix unmarshal mutate or get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dolan-in/dgman/v2
 
 require (
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453
-	github.com/dolan-in/reflectwalk v1.0.2-0.20201231054028-585ac6716cbe
+	github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.7
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453 h1:DTgOrw91nM
 github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453/go.mod h1:Co+FwJrnndSrPORO8Gdn20dR7FPTfmXr0W/su0Ve/Ig=
 github.com/dolan-in/reflectwalk v1.0.2-0.20201231054028-585ac6716cbe h1:F2WtVoEnV4WK2l653VCjRPItWMUuNuY3jm/e990jEkI=
 github.com/dolan-in/reflectwalk v1.0.2-0.20201231054028-585ac6716cbe/go.mod h1:Y9TyDkSL5jQ18ZnDaSxOdCUhbb5SCeamqYFQ7LYxxFs=
+github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71 h1:v3bErDrPApxsyBlz8/8nFTCb7Ai0wecA8TokfEHIQ80=
+github.com/dolan-in/reflectwalk v1.0.2-0.20210101124621-dc2073a29d71/go.mod h1:Y9TyDkSL5jQ18ZnDaSxOdCUhbb5SCeamqYFQ7LYxxFs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=

--- a/mutate_test.go
+++ b/mutate_test.go
@@ -222,6 +222,12 @@ func TestMutationMutateOrGet(t *testing.T) {
 	uids, err = tx.MutateOrGet(&user2)
 	require.NoError(t, err)
 
+	sortByUID := ByUID{TestSchoolList: user1.Schools}
+	sort.Sort(sortByUID)
+
+	sortByUID = ByUID{TestSchoolList: user2.Schools}
+	sort.Sort(sortByUID)
+
 	assert.Len(t, uids, 0)
 	assert.Equal(t, user1, user2)
 
@@ -231,10 +237,7 @@ func TestMutationMutateOrGet(t *testing.T) {
 	err = tx.Get(&user).UID(user2.UID).All(3).Node()
 	require.NoError(t, err)
 
-	sortByUID := ByUID{TestSchoolList: user.Schools}
-	sort.Sort(sortByUID)
-
-	sortByUID = ByUID{TestSchoolList: user2.Schools}
+	sortByUID = ByUID{TestSchoolList: user.Schools}
 	sort.Sort(sortByUID)
 
 	assert.Equal(t, user2, user)


### PR DESCRIPTION
Fix unmarshal on `MutateOrGet`, skip unmarshal on node when parent node is already set/unmarshalled.