### PR TITLE
 Apply cascaded queries to NodeAndCount count queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 	- [Delete](#delete)
 	- [Delete Query](#delete-query)
 	- [Delete Node](#delete-node)
-	- [Delete Edge](#delete-edge)
+	- [Delete Edge](#delete-edges)
  - [Development](#development)
 
 ## Installation
@@ -550,6 +550,8 @@ count, err := tx.Get(&users).
 // count should return total of nodes regardless of pagination
 fmt.Println(count)
 ```
+
+Note: `Query.query` will only be applied to the count query if `Query.Cascade` is provided as node filters do not affect the overall count unless cascaded.
 
 #### Custom Scanning Query results
 

--- a/query.go
+++ b/query.go
@@ -426,6 +426,12 @@ func (q *Query) nodes(jsonData []byte, dst interface{}) error {
 func (q *Query) NodesAndCount() (count int, err error) {
 	tx := TxnContext{txn: q.tx, ctx: q.ctx}
 
+	var qr string
+	// only apply the query if the result will be cascaded
+	if q.cascade != nil {
+		qr = q.query
+	}
+
 	pagedResult := PagedResults{}
 	query := tx.Query(
 		&Query{
@@ -435,6 +441,8 @@ func (q *Query) NodesAndCount() (count int, err error) {
 			rootFunc: q.rootFunc,
 			model:    q.model,
 			filter:   q.filter,
+			query:    qr,
+			cascade:  q.cascade,
 		},
 		&Query{
 			name:   "result",


### PR DESCRIPTION
Applies cascade and query to NodeAndCount queries to fix the erroneous counts being returned on cascaded queries 

Closes #93 