### PR TITLE
fix: Set schema unique tag if upsert is defined

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -395,6 +395,7 @@ func parseStructTag(tag string) (*rawSchema, error) {
 			schema.List = true
 		case "upsert":
 			schema.Upsert = true
+			schema.Unique = true
 		case "lang":
 			schema.Lang = true
 		case "noconflict":


### PR DESCRIPTION
This PR sets the unique field in schema when the upsert tag is used (upsert on a predicate implies a unique nature)